### PR TITLE
Move `SideMenuLayout` to page components

### DIFF
--- a/.changeset/rich-coats-double.md
+++ b/.changeset/rich-coats-double.md
@@ -1,0 +1,5 @@
+---
+"copipe": patch
+---
+
+Move layout component to page files.

--- a/src/app/(side-menu-layout)/archives/[id]/layout.tsx
+++ b/src/app/(side-menu-layout)/archives/[id]/layout.tsx
@@ -1,4 +1,3 @@
-import SideMenuLayout from "@/modules/layouts/sideMenuLayout"
 import { Metadata } from "next"
 import { ReactNode } from "react"
 
@@ -7,5 +6,5 @@ export const metadata: Metadata = {
 }
 
 export default function layout({ children }: { children: ReactNode }) {
-  return <SideMenuLayout>{children}</SideMenuLayout>
+  return <>{children}</>
 }

--- a/src/app/(side-menu-layout)/archives/[id]/page.tsx
+++ b/src/app/(side-menu-layout)/archives/[id]/page.tsx
@@ -1,3 +1,4 @@
+import SideMenuLayout from "@/modules/layouts/sideMenuLayout"
 import { Suspense } from "react"
 
 import ArchivePageLoading from "./page-loading"
@@ -5,8 +6,10 @@ import { ArchivePageTemplate } from "./page-template"
 
 export default function page({ params }: { params: Promise<{ id: string }> }) {
   return (
-    <Suspense fallback={<ArchivePageLoading />}>
-      <ArchivePageTemplate params={params} />
-    </Suspense>
+    <SideMenuLayout>
+      <Suspense fallback={<ArchivePageLoading />}>
+        <ArchivePageTemplate params={params} />
+      </Suspense>
+    </SideMenuLayout>
   )
 }

--- a/src/app/(side-menu-layout)/search/layout.tsx
+++ b/src/app/(side-menu-layout)/search/layout.tsx
@@ -1,4 +1,3 @@
-import SideMenuLayout from "@/modules/layouts/sideMenuLayout"
 import { ReactNode } from "react"
 
 export const metadata = {
@@ -6,5 +5,5 @@ export const metadata = {
 }
 
 export default function layout({ children }: { children: ReactNode }) {
-  return <SideMenuLayout>{children}</SideMenuLayout>
+  return <>{children}</>
 }

--- a/src/app/(side-menu-layout)/search/page.tsx
+++ b/src/app/(side-menu-layout)/search/page.tsx
@@ -1,3 +1,4 @@
+import SideMenuLayout from "@/modules/layouts/sideMenuLayout"
 import { Suspense } from "react"
 
 import { SearchPageLoading } from "./page-loading"
@@ -9,8 +10,10 @@ export default function page({
   searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   return (
-    <Suspense fallback={<SearchPageLoading />}>
-      <SearchPageTemplate searchParams={searchParams} />
-    </Suspense>
+    <SideMenuLayout>
+      <Suspense fallback={<SearchPageLoading />}>
+        <SearchPageTemplate searchParams={searchParams} />
+      </Suspense>
+    </SideMenuLayout>
   )
 }

--- a/src/app/(side-menu-layout)/tag/[tagId]/layout.tsx
+++ b/src/app/(side-menu-layout)/tag/[tagId]/layout.tsx
@@ -1,4 +1,3 @@
-import SideMenuLayout from "@/modules/layouts/sideMenuLayout"
 import { Metadata } from "next"
 import { ReactNode } from "react"
 
@@ -7,5 +6,5 @@ export const metadata: Metadata = {
 }
 
 export default function layout({ children }: { children: ReactNode }) {
-  return <SideMenuLayout>{children}</SideMenuLayout>
+  return <>{children}</>
 }

--- a/src/app/(side-menu-layout)/tag/[tagId]/page.tsx
+++ b/src/app/(side-menu-layout)/tag/[tagId]/page.tsx
@@ -1,6 +1,7 @@
 import { fetchTagCopipes } from "@/db/server/copipes"
 import { CopipeCardItem } from "@/modules/copipeCardItem"
 import CopipePagination from "@/modules/copipePagination"
+import SideMenuLayout from "@/modules/layouts/sideMenuLayout"
 import { Container, VStack } from "@yamada-ui/react"
 
 export default async function page(props: {
@@ -16,17 +17,19 @@ export default async function page(props: {
   const [copipes, count] = await fetchTagCopipes(tagId, page)
 
   return (
-    <VStack>
-      <Container>
-        {copipes.map((e) => (
-          <CopipeCardItem copipeItem={e} key={e.id} />
-        ))}
-      </Container>
-      <CopipePagination
-        page={page}
-        total={Math.ceil(count / 10)}
-        url={`/tag/${tagId}`}
-      />
-    </VStack>
+    <SideMenuLayout>
+      <VStack>
+        <Container>
+          {copipes.map((e) => (
+            <CopipeCardItem copipeItem={e} key={e.id} />
+          ))}
+        </Container>
+        <CopipePagination
+          page={page}
+          total={Math.ceil(count / 10)}
+          url={`/tag/${tagId}`}
+        />
+      </VStack>
+    </SideMenuLayout>
   )
 }


### PR DESCRIPTION
Related #144 
## Description

<!-- Add a brief description. -->
Moved `SideMenuLayout` from `layout.tsx` to `page.tsx` file.
Even if same lavel layout component, style is flash.