### PR TITLE
Fixed cache data

### DIFF
--- a/.changeset/loose-bees-speak.md
+++ b/.changeset/loose-bees-speak.md
@@ -1,0 +1,5 @@
+---
+"copipe": patch
+---
+
+Fixed layout component is not cached in dynamic routing.

--- a/src/db/server/copipes.ts
+++ b/src/db/server/copipes.ts
@@ -19,6 +19,10 @@ export async function getHomePageCopipe() {
 export type FetchCopipeReturn = ReturnType<typeof fetchCopipe>
 
 export async function fetchRecentCopipes() {
+  "use cache: remote"
+  cacheTag("recent-copipes")
+  cacheLife("weeks")
+
   const copipes = await prisma.copipe.findMany({
     orderBy: { id: "desc" },
     select: {

--- a/src/db/server/tags.ts
+++ b/src/db/server/tags.ts
@@ -1,9 +1,13 @@
-import { cacheTag } from "next/cache"
+import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
 import { Tag } from "@/models/tag"
 import { prisma } from "../db"
 
 export async function fetchTags() {
+  "use cache: remote"
+  cacheTag("tags")
+  cacheLife("max")
+
   const tags = await prisma.tag.findMany()
 
   console.log("get tag list")


### PR DESCRIPTION
Related #313 

## Description

<!-- Add a brief description. -->
Fixed side menu comonent is not cached in dynamic routing.
## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Cache remote in layout component data.
## Is this a breaking change (Yes/No): No
